### PR TITLE
Bugfix - Tab select for filtered options 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-crane",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/select/SimpleSelect.js
+++ b/src/select/SimpleSelect.js
@@ -337,20 +337,21 @@ class SimpleSelect extends Component {
   }
 
   emitValueChange = (option, event) => {
-    const { clearInputOnSelect, value, valueKey, labelKey, inputValue } = this.props
-    const valueSelected = (option === null || value === null) && option !== value
+    const { clearInputOnSelect, value, valueKey, labelKey, inputValue, options } = this.props
+    const hasOptions = options && options.length > 0
+    const valueSelected = hasOptions && (option === null || value === null) && option !== value
     const selectValueProps = _.omit(this.props, 'getSelectValue')
     const valueObj = this.props.getSelectValue(selectValueProps)
-    const valueChanged = _.isArray(value)
+    const valueChanged = (_.isArray(value) && hasOptions)
       ? true
-      : (!valueObj || (value && option && valueObj[valueKey] !== option[valueKey]))
+      : (hasOptions && (!valueObj || (value && option && valueObj[valueKey] !== option[valueKey])))
 
     if ((valueSelected || valueChanged) && this.props.onChange) {
       const eventContext = { name: this.props.name, value: option }
       this.props.onChange(eventContext, event)
     }
 
-    const newInputVal = !clearInputOnSelect && option !== null ? option[labelKey] : ''
+    const newInputVal = !clearInputOnSelect && hasOptions && option !== null ? option[labelKey] : ''
     if (newInputVal !== inputValue) {
       this.setInputValue(event, newInputVal)
     }


### PR DESCRIPTION
When tabbing out of a dropdown, if there are no results in the dropdown because of filtering, the previously highlighted value is no longer selected.