### PR TITLE
Allow passing an icon into the placeholder.

### DIFF
--- a/src/select/ValueGroup.js
+++ b/src/select/ValueGroup.js
@@ -8,7 +8,7 @@ class ValueGroup extends Component {
     inputValue: PropTypes.string,
     labelKey: PropTypes.string,
     onMouseDown: PropTypes.func,
-    placeholder: PropTypes.string,
+    placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     showInput: PropTypes.bool,
     value: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.string]),
     valueComponent: PropTypes.func,

--- a/src/select/utils/PropTypes.js
+++ b/src/select/utils/PropTypes.js
@@ -43,7 +43,7 @@ export const simpleSelectPropTypes = {
   optionGroupRenderer: PropTypes.func,
   optionRenderer: PropTypes.func,
   options: PropTypes.array,
-  placeholder: PropTypes.string,
+  placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   showInput: PropTypes.bool,
   value: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.string]),
   valueComponent: PropTypes.func,


### PR DESCRIPTION
Update proptypes to allow passing an icon, like from font awesome, into the placeholder.