### PR TITLE
Fix static option keyboard navigation

### DIFF
--- a/src/select/Menu.js
+++ b/src/select/Menu.js
@@ -24,12 +24,12 @@ class Menu extends Component {
       valueKey
     } = this.props
 
-    const OptionComponent = optionComponent
-    const OptionGroupComponent = optionGroupComponent
-
     if (!options) {
       return null
     }
+
+    const OptionComponent = optionComponent
+    const OptionGroupComponent = optionGroupComponent
 
     const optionProps = {
       onOptionClick,
@@ -56,6 +56,7 @@ class Menu extends Component {
     return options.map((option) => {
       const isFocused = option === focusedOption
 
+      // Nested options
       if (option.options && Array.isArray(option.options)) {
         // TODO: undo the recursion so we can convert this to a function component
         return (

--- a/src/select/SimpleSelect.js
+++ b/src/select/SimpleSelect.js
@@ -317,10 +317,17 @@ class SimpleSelect extends Component {
 
   getFocusedOption(direction, options) {
     const isOpen = this.props.isOpen || this.state.isOpen
-    const { allowSelectAll, allOption, valueKey } = this.props
+    const {
+      allowSelectAll,
+      allOption,
+      staticOption,
+      valueKey
+    } = this.props
     const { focusedOption } = this.state
 
-    const flatOptions = flattenOptions(options, allowSelectAll, allOption)
+    const flatOptions = staticOption
+      ? flattenOptions([...options, staticOption], allowSelectAll, allOption)
+      : flattenOptions(options, allowSelectAll, allOption)
 
     let currentIndex = focusedOption
       ? flatOptions.findIndex(option => (option[valueKey] === focusedOption[valueKey]))

--- a/stories/index.js
+++ b/stories/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { withKnobs, boolean, number, text } from '@storybook/addon-knobs'
+import { withKnobs, boolean, number, text, object } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
 
 import {
@@ -116,7 +116,7 @@ stories.add('with SimpleSelect and Static Option', () => (
     options={states}
     placeholder={text('Placeholder', 'Select value...')}
     showInput={boolean('Show Input', false)}
-    staticOption={{ name: 'Add New State', abbreviation: 'STATIC_ADD_NEW_STATE' }}
+    staticOption={object('Static Option', { name: 'Add New State', abbreviation: 'STATIC_ADD_NEW_STATE' })}
     valueKey="abbreviation"
   />
 ))
@@ -301,6 +301,21 @@ stories.add('with FilterSelect', () => (
     openOnEmptyInput={boolean('Open On Empty Input', true)}
     options={states}
     placeholder={text('Placeholder', 'Select value...')}
+    valueKey="abbreviation"
+  />
+))
+
+stories.add('with FilterSelect and static option', () => (
+  <BasicFilterSelect
+    autoCloseMenu={boolean('Auto Close Menu', true)}
+    clearable={boolean('Clearable', false)}
+    isOpen={boolean('Is Open', false)}
+    labelKey="name"
+    openOnClick={boolean('Open On Click', true)}
+    openOnEmptyInput={boolean('Open On Empty Input', true)}
+    options={states}
+    placeholder={text('Placeholder', 'Select value...')}
+    staticOption={object('Static Option', { name: 'Add New State', abbreviation: 'STATIC_ADD_NEW_STATE' })}
     valueKey="abbreviation"
   />
 ))


### PR DESCRIPTION
Keyboard arrow navigation was skipping the static option.

`getFocusedOption` and `focusOnOption` did not account for the staticOption when calculating the next index.