### PR TITLE
FIX: proper a11y for menu

### DIFF
--- a/src/select/SimpleSelect.js
+++ b/src/select/SimpleSelect.js
@@ -638,7 +638,7 @@ class SimpleSelect extends Component {
     if (opts.length || hasStaticOptions) {
       const MenuComponent = menuComponent
       menu = (
-        <div className="crane-select-menu-container" role="listbox">
+        <div id="crane-select-menu-container" className="crane-select-menu-container">
           <MenuComponent {...menuProps} options={opts} />
         </div>
       )


### PR DESCRIPTION
Remove role from menu container to fix double listbox problem.
Add id to container to fix aria-controls.