### PR TITLE
FIX: Adjust a11y attributes for JAWs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": ["eslint-config-airbnb", "prettier", "plugin:jest/recommended"],
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "env": {
     "browser": true,
     "node": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -237,6 +237,35 @@
         }
       }
     },
+    "@babel/eslint-parser": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.17.0.tgz",
+      "integrity": "sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/generator": {
       "version": "7.16.8",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
@@ -18438,6 +18467,12 @@
           "dev": true
         }
       }
+    },
+    "eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true
     },
     "espree": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",
+    "@babel/eslint-parser": "^7.17.0",
     "@babel/plugin-transform-runtime": "^7.16.8",
     "@babel/preset-env": "^7.14.4",
     "@babel/preset-react": "^7.13.13",

--- a/src/select/FocusPlaceholder.js
+++ b/src/select/FocusPlaceholder.js
@@ -3,10 +3,13 @@ import PropTypes from 'prop-types'
 
 class FocusPlaceholder extends PureComponent {
   render() {
-    const { onBlur, onFocus, getRef } = this.props
+    const { onBlur, onFocus, getRef, id, ...ariaProps } = this.props
 
     return (
       <input
+        id={id}
+        aria-activedescendant={ariaProps['aria-activedescendant'] || undefined}
+        aria-controls={ariaProps['aria-controls'] || undefined}
         aria-label="placeholder text"
         className="crane-select-focus-placeholder"
         onBlur={onBlur}
@@ -19,9 +22,17 @@ class FocusPlaceholder extends PureComponent {
 }
 
 FocusPlaceholder.propTypes = {
+  'aria-activedescendant': PropTypes.string,
+  'aria-controls': PropTypes.string,
   getRef: PropTypes.func.isRequired,
+  id: PropTypes.string.isRequired,
   onBlur: PropTypes.func.isRequired,
   onFocus: PropTypes.func.isRequired
+}
+
+FocusPlaceholder.defaultProps = {
+  'aria-activedescendant': undefined,
+  'aria-controls': undefined
 }
 
 export default FocusPlaceholder

--- a/src/select/FocusPlaceholder.test.js
+++ b/src/select/FocusPlaceholder.test.js
@@ -8,6 +8,7 @@ it('does not explode', () => {
     <FocusPlaceholder
       ariaControls=""
       ariaExpanded=""
+      id="foo"
       getRef={() => {}}
       onBlur={() => {}}
       onFocus={() => {}}

--- a/src/select/Input.js
+++ b/src/select/Input.js
@@ -6,6 +6,8 @@ function Input({ disabled, getRef, id, inputValue, onBlur, onChange, onFocus, ..
     <div className="crane-select-input">
       <input
         id={id}
+        aria-activedescendant={ariaProps['aria-activedescendant'] || undefined}
+        aria-controls={ariaProps['aria-controls'] || undefined}
         aria-label={ariaProps['aria-label'] || undefined}
         aria-labelledby={ariaProps['aria-labelledby'] || undefined}
         autoCapitalize="none"
@@ -25,6 +27,8 @@ function Input({ disabled, getRef, id, inputValue, onBlur, onChange, onFocus, ..
 }
 
 Input.propTypes = {
+  'aria-activedescendant': PropTypes.string,
+  'aria-controls': PropTypes.string,
   'aria-label': PropTypes.string,
   'aria-labelledby': PropTypes.string,
   disabled: PropTypes.bool,
@@ -37,8 +41,10 @@ Input.propTypes = {
 }
 
 Input.defaultProps = {
+  'aria-activedescendant': undefined,
+  'aria-controls': undefined,
   'aria-label': 'select input',
-  'aria-labelledby': '',
+  'aria-labelledby': undefined,
   disabled: false,
   id: null,
   inputValue: ''

--- a/src/select/Option.js
+++ b/src/select/Option.js
@@ -61,9 +61,14 @@ class Option extends PureComponent {
           ? ' crane-select-group-header'
           : ''
       }`
+    const optionDomId = `crane-item-${option[valueKey]}`
 
     return (
+      // options get psuedo focus while DOM focus remains on the input.
+      // There is no need for a tabindex on the option.
+      // eslint-disable-next-line jsx-a11y/interactive-supports-focus
       <div
+        id={optionDomId}
         ref={(el) => optionRef(el, option[valueKey])}
         aria-disabled={isDisabled}
         aria-selected={selected}
@@ -73,7 +78,6 @@ class Option extends PureComponent {
         onMouseMove={this.handleFocus}
         onFocus={this.handleFocus}
         role="option"
-        tabIndex="0"
       >
         {renderer}
       </div>

--- a/src/select/OptionGroup.js
+++ b/src/select/OptionGroup.js
@@ -67,9 +67,14 @@ class OptionGroup extends PureComponent {
             option.options.length > 0 &&
             option.options.some((opt) => isValueEqual(opt, val, valueKey)))
       )
+    const optionDomId = `crane-item-${option[groupValueKey]}`
 
     return (
+      // options get psuedo focus while DOM focus remains on the input.
+      // There is no need for a tabindex on the option.
+      // eslint-disable-next-line jsx-a11y/interactive-supports-focus
       <div
+        id={optionDomId}
         ref={(el) => optionRef(el, option[valueKey])}
         aria-selected={selected}
         className="crane-select-option"
@@ -77,7 +82,6 @@ class OptionGroup extends PureComponent {
         onMouseEnter={this.handleFocus}
         onMouseMove={this.handleFocus}
         role="option"
-        tabIndex="0"
       >
         <span className="crane-select-group-header">{renderer}</span>
         {children}

--- a/src/select/SearchSelect.test.js
+++ b/src/select/SearchSelect.test.js
@@ -4,7 +4,7 @@ import { mount } from 'enzyme'
 import SearchSelect from './SearchSelect'
 
 it('does not explode', () => {
-  const select = <SearchSelect inputValue="" onInputChange={() => {}} />
+  const select = <SearchSelect id="foo" inputValue="" onInputChange={() => {}} />
   const wrapper = mount(select)
 
   expect(wrapper).toExist()

--- a/src/select/SimpleSelect.js
+++ b/src/select/SimpleSelect.js
@@ -680,10 +680,10 @@ class SimpleSelect extends Component {
     // eslint-disable-next-line react/destructuring-assignment
     const isOpen = this.props.isOpen || this.state.isOpen
     const { focusedOption } = this.state
-    const focusedOptionDomID = focusedOption ? `crane-item-${focusedOption[valueKey]}` : undefined
+    const focusedOptionDomId = focusedOption ? `crane-item-${focusedOption[valueKey]}` : undefined
 
     const inputProps = {
-      'aria-activedescendant': focusedOptionDomID,
+      'aria-activedescendant': isOpen ? focusedOptionDomId : undefined,
       'aria-controls': isOpen ? `crane-select-menu-${id}` : undefined,
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,

--- a/src/select/SimpleSelect.js
+++ b/src/select/SimpleSelect.js
@@ -158,6 +158,7 @@ class SimpleSelect extends Component {
     })
 
     this.setState((prevState) => ({
+      // eslint-disable-next-line react/destructuring-assignment
       isOpen: this.props.isOpen || prevState.isOpen,
       isFocused: true
     }))
@@ -183,6 +184,7 @@ class SimpleSelect extends Component {
 
   handleKeyDown = (event) => {
     const { disabled, inputValue, onKeyDown } = this.props
+    // eslint-disable-next-line react/destructuring-assignment
     const isOpen = this.props.isOpen || this.state.isOpen
 
     if (disabled) {
@@ -520,6 +522,7 @@ class SimpleSelect extends Component {
   }
 
   // check for right-clicks, etc
+  // eslint-disable-next-line class-methods-use-this
   isSecondaryClick = (event) => event.type === 'mousedown' && event.button !== 0
 
   focus = () => {
@@ -607,7 +610,7 @@ class SimpleSelect extends Component {
   }
 
   renderMenu() {
-    const { isLoading, loadingText, noResultsText, staticOption } = this.props
+    const { isLoading, loadingText, id, noResultsText, staticOption } = this.props
     const { focusedOption } = this.state
     const { menuComponent, options, ...otherProps } = this.props
     const menuProps = {
@@ -631,7 +634,7 @@ class SimpleSelect extends Component {
     if (opts.length || hasStaticOptions) {
       const MenuComponent = menuComponent
       menu = (
-        <div id="crane-select-menu-container" className="crane-select-menu-container">
+        <div id={`crane-select-menu-${id}`} className="crane-select-menu-container">
           <MenuComponent {...menuProps} options={opts} />
         </div>
       )
@@ -667,20 +670,28 @@ class SimpleSelect extends Component {
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
       disabled,
+      id,
       inputComponent,
       inputId,
       inputValue,
-      showInput
+      showInput,
+      valueKey
     } = this.props
+    // eslint-disable-next-line react/destructuring-assignment
+    const isOpen = this.props.isOpen || this.state.isOpen
+    const { focusedOption } = this.state
+    const focusedOptionDomID = focusedOption ? `crane-item-${focusedOption[valueKey]}` : undefined
 
     const inputProps = {
+      'aria-activedescendant': focusedOptionDomID,
+      'aria-controls': isOpen ? `crane-select-menu-${id}` : undefined,
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
       disabled,
       getRef: (ref) => {
         this.input = ref
       },
-      id: inputId,
+      id: inputId || `crane-select-input-${id}`,
       inputValue,
       onBlur: this.handleInputBlur,
       onChange: this.handleInputChange,
@@ -713,6 +724,9 @@ class SimpleSelect extends Component {
       disabled
     })
 
+    // jsx-a11y is wrong here. role=combobox does not need aria-controls. That belongs on the input.
+    // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/789
+    /* eslint-disable jsx-a11y/role-has-required-aria-props */
     return (
       <div aria-expanded={isOpen} className={selectClassName}>
         <div
@@ -727,7 +741,7 @@ class SimpleSelect extends Component {
           <div className="crane-select-outer-input">
             {beforeInput}
             <div
-              aria-controls={isOpen ? 'crane-select-menu-container' : null}
+              aria-owns={isOpen ? `crane-select-menu-${id}` : undefined}
               aria-expanded={isOpen}
               aria-haspopup="listbox"
               className={
@@ -748,6 +762,7 @@ class SimpleSelect extends Component {
         {isOpen && this.renderMenu()}
       </div>
     )
+    /* eslint-enable jsx-a11y/role-has-required-aria-props */
   }
 }
 

--- a/src/select/SimpleSelect.test.js
+++ b/src/select/SimpleSelect.test.js
@@ -4,7 +4,7 @@ import { mount } from 'enzyme'
 import SimpleSelect from './SimpleSelect'
 
 it('does not explode', () => {
-  const select = <SimpleSelect />
+  const select = <SimpleSelect id="foo" />
   const wrapper = mount(select)
 
   expect(wrapper).toExist()
@@ -14,7 +14,7 @@ it('should emit onOpen and onClosed events when props change', () => {
   const onOpen = jest.fn().mockName('onOpen')
   const onClose = jest.fn().mockName('onClose')
 
-  const select = <SimpleSelect onOpen={onOpen} onClose={onClose} />
+  const select = <SimpleSelect id="foo" onOpen={onOpen} onClose={onClose} />
   const wrapper = mount(select)
 
   wrapper.setProps({ isOpen: true })
@@ -32,7 +32,7 @@ it('should emit onOpen and onClose events when state changes', () => {
   const onOpen = jest.fn().mockName('onOpen')
   const onClose = jest.fn().mockName('onClose')
 
-  const select = <SimpleSelect onOpen={onOpen} onClose={onClose} />
+  const select = <SimpleSelect id="foo" onOpen={onOpen} onClose={onClose} />
   const wrapper = mount(select)
 
   wrapper.setState({ isOpen: true })
@@ -47,21 +47,21 @@ it('should emit onOpen and onClose events when state changes', () => {
 })
 
 it('should not show loading placeholder by default when open', () => {
-  const select = <SimpleSelect isOpen />
+  const select = <SimpleSelect id="foo" isOpen />
   const wrapper = mount(select)
 
   expect(wrapper.find('.crane-select-loading-text')).not.toExist()
 })
 
 it('should show no results text when open', () => {
-  const select = <SimpleSelect noResultsText="Foo" isOpen />
+  const select = <SimpleSelect id="foo" noResultsText="Foo" isOpen />
   const wrapper = mount(select)
 
   expect(wrapper.find('.crane-select-no-results')).toHaveText('Foo')
 })
 
 it('should show loading placeholder when isLoading and has loadingText', () => {
-  const select = <SimpleSelect isLoading loadingText="Bar" isOpen />
+  const select = <SimpleSelect id="foo" isLoading loadingText="Bar" isOpen />
   const wrapper = mount(select)
 
   expect(wrapper.find('.crane-select-loading-text')).toHaveText('Bar')

--- a/src/select/index.js
+++ b/src/select/index.js
@@ -1,15 +1,15 @@
-import Arrow from "./Arrow";
-import Clear from "./Clear";
-import FocusPlaceholder from "./FocusPlaceholder";
-import FilterSelect from "./FilterSelect";
-import Input from "./Input";
-import Menu from "./Menu";
-import MultiSelect from "./multiselect/MultiSelect";
-import Option from "./Option";
-import SearchSelect from "./SearchSelect";
-import SimpleSelect from "./SimpleSelect";
-import Value from "./Value";
-import ValueGroup from "./ValueGroup";
+import Arrow from './Arrow'
+import Clear from './Clear'
+import FocusPlaceholder from './FocusPlaceholder'
+import FilterSelect from './FilterSelect'
+import Input from './Input'
+import Menu from './Menu'
+import MultiSelect from './multiselect/MultiSelect'
+import Option from './Option'
+import SearchSelect from './SearchSelect'
+import SimpleSelect from './SimpleSelect'
+import Value from './Value'
+import ValueGroup from './ValueGroup'
 
 export {
   Arrow,
@@ -24,6 +24,6 @@ export {
   SimpleSelect,
   Value,
   ValueGroup
-};
+}
 
-export * from "./utils";
+export * from './utils'

--- a/src/select/multiselect/MultiSelect.test.js
+++ b/src/select/multiselect/MultiSelect.test.js
@@ -4,7 +4,7 @@ import { mount } from 'enzyme'
 import MultiSelect from './MultiSelect'
 
 it('does not explode', () => {
-  const select = <MultiSelect />
+  const select = <MultiSelect id="foo" />
   const wrapper = mount(select)
 
   expect(wrapper).toExist()

--- a/src/select/utils/PropTypes.js
+++ b/src/select/utils/PropTypes.js
@@ -23,7 +23,7 @@ export const simpleSelectPropTypes = {
   groups: PropTypes.array,
   groupTitleKey: PropTypes.string,
   groupValueKey: PropTypes.string,
-  id: PropTypes.string,
+  id: PropTypes.string.isRequired,
   inputComponent: PropTypes.func,
   inputId: PropTypes.string,
   inputValue: PropTypes.string,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -234,7 +234,7 @@ export interface SimpleSelectProps {
   groups?: object[]
   groupTitleKey?: string
   groupValueKey?: string
-  id?: string
+  id: string
   inputComponent?: React.ReactNode
   inputId?: string
   inputValue?: string


### PR DESCRIPTION
Add aria-activedescendant to Input so screen-readers like JAWs can know which option is "focused" while DOM focus remains on the input.
Move aria-controls to Input per aria standards.
Add aria-owns to the combobox element so screen-readers know the listbox should immediately follows the input in reading order.
Remove tabindex=0 from Option. Unneeded.
Give the menu element a unique id.

https://www.w3.org/TR/wai-aria-practices-1.1/examples/combobox/aria1.1pattern/listbox-combo.html