### PR TITLE
Focus on Multiple Static options

### DIFF
--- a/src/select/SimpleSelect.js
+++ b/src/select/SimpleSelect.js
@@ -381,7 +381,8 @@ class SimpleSelect extends Component {
 
   focusOnOption = (direction) => {
     const { labelKey, options, staticOption } = this.props
-    const newFocusedOption = options.length
+    const multiStaticOptions = Array.isArray(staticOption)
+    const newFocusedOption = options.length || multiStaticOptions
       ? this.getFocusedOption(direction, options)
       : staticOption || null
 


### PR DESCRIPTION
Previously not detecting when multiple static options were present, making the options not able to focus with arrow keys.